### PR TITLE
T4 Changes to introduce Try Block with timeout exception handling

### DIFF
--- a/EmpyrionNetAPIBroker/Autowire.Broker.APIRequestsDefinition.cs
+++ b/EmpyrionNetAPIBroker/Autowire.Broker.APIRequestsDefinition.cs
@@ -18,903 +18,1477 @@ namespace EmpyrionNetAPIAccess
 		public async static Task<PlayfieldList> Request_Playfield_List(this Broker broker) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync<PlayfieldList>(CmdId.Request_Playfield_List, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<PlayfieldList>(CmdId.Request_Playfield_List, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(PlayfieldList);
+				}
 			}
 		}
 
 		public async static Task<PlayfieldList> Request_Playfield_List(this Broker broker, CancellationToken ct) {
-				return await broker.SendRequestAsync<PlayfieldList>(CmdId.Request_Playfield_List, ct);
+			return await broker.SendRequestAsync<PlayfieldList>(CmdId.Request_Playfield_List, ct);
 		}
 		
 		public async static Task<PlayfieldList> Request_Playfield_List(this Broker broker, Timeouts timeoutSeconds) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync<PlayfieldList>(CmdId.Request_Playfield_List, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<PlayfieldList>(CmdId.Request_Playfield_List, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(PlayfieldList);
+				}
 			}
 		}
 
 		public async static Task<PlayfieldList> Request_Playfield_List(this Broker broker, Timeouts timeoutSeconds, CancellationToken ct) {
-				return await broker.SendRequestAsync<PlayfieldList>(CmdId.Request_Playfield_List, ct);
+			return await broker.SendRequestAsync<PlayfieldList>(CmdId.Request_Playfield_List, ct);
 		}
 	
 		public async static Task<PlayfieldStats> Request_Playfield_Stats(this Broker broker, PString arg) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync<PString, PlayfieldStats>(CmdId.Request_Playfield_Stats, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<PString, PlayfieldStats>(CmdId.Request_Playfield_Stats, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(PlayfieldStats);
+				}
 			}
 		}
 
 		public async static Task<PlayfieldStats> Request_Playfield_Stats(this Broker broker, PString arg, CancellationToken ct) {
-				return await broker.SendRequestAsync<PString, PlayfieldStats>(CmdId.Request_Playfield_Stats, arg, ct);
+			return await broker.SendRequestAsync<PString, PlayfieldStats>(CmdId.Request_Playfield_Stats, arg, ct);
 		}
 		
 		public async static Task<PlayfieldStats> Request_Playfield_Stats(this Broker broker, Timeouts timeoutSeconds, PString arg) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync<PString, PlayfieldStats>(CmdId.Request_Playfield_Stats, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<PString, PlayfieldStats>(CmdId.Request_Playfield_Stats, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(PlayfieldStats);
+				}
 			}
 		}
 
 		public async static Task<PlayfieldStats> Request_Playfield_Stats(this Broker broker, Timeouts timeoutSeconds, PString arg, CancellationToken ct) {
-				return await broker.SendRequestAsync<PString, PlayfieldStats>(CmdId.Request_Playfield_Stats, arg, ct);
+			return await broker.SendRequestAsync<PString, PlayfieldStats>(CmdId.Request_Playfield_Stats, arg, ct);
 		}
 	
 		public async static Task<DediStats> Request_Dedi_Stats(this Broker broker) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync<DediStats>(CmdId.Request_Dedi_Stats, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<DediStats>(CmdId.Request_Dedi_Stats, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(DediStats);
+				}
 			}
 		}
 
 		public async static Task<DediStats> Request_Dedi_Stats(this Broker broker, CancellationToken ct) {
-				return await broker.SendRequestAsync<DediStats>(CmdId.Request_Dedi_Stats, ct);
+			return await broker.SendRequestAsync<DediStats>(CmdId.Request_Dedi_Stats, ct);
 		}
 		
 		public async static Task<DediStats> Request_Dedi_Stats(this Broker broker, Timeouts timeoutSeconds) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync<DediStats>(CmdId.Request_Dedi_Stats, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<DediStats>(CmdId.Request_Dedi_Stats, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(DediStats);
+				}
 			}
 		}
 
 		public async static Task<DediStats> Request_Dedi_Stats(this Broker broker, Timeouts timeoutSeconds, CancellationToken ct) {
-				return await broker.SendRequestAsync<DediStats>(CmdId.Request_Dedi_Stats, ct);
+			return await broker.SendRequestAsync<DediStats>(CmdId.Request_Dedi_Stats, ct);
 		}
 	
 		public async static Task<GlobalStructureList> Request_GlobalStructure_List(this Broker broker) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync<GlobalStructureList>(CmdId.Request_GlobalStructure_List, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<GlobalStructureList>(CmdId.Request_GlobalStructure_List, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(GlobalStructureList);
+				}
 			}
 		}
 
 		public async static Task<GlobalStructureList> Request_GlobalStructure_List(this Broker broker, CancellationToken ct) {
-				return await broker.SendRequestAsync<GlobalStructureList>(CmdId.Request_GlobalStructure_List, ct);
+			return await broker.SendRequestAsync<GlobalStructureList>(CmdId.Request_GlobalStructure_List, ct);
 		}
 		
 		public async static Task<GlobalStructureList> Request_GlobalStructure_List(this Broker broker, Timeouts timeoutSeconds) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync<GlobalStructureList>(CmdId.Request_GlobalStructure_List, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<GlobalStructureList>(CmdId.Request_GlobalStructure_List, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(GlobalStructureList);
+				}
 			}
 		}
 
 		public async static Task<GlobalStructureList> Request_GlobalStructure_List(this Broker broker, Timeouts timeoutSeconds, CancellationToken ct) {
-				return await broker.SendRequestAsync<GlobalStructureList>(CmdId.Request_GlobalStructure_List, ct);
+			return await broker.SendRequestAsync<GlobalStructureList>(CmdId.Request_GlobalStructure_List, ct);
 		}
 	
 		public async static Task<bool> Request_GlobalStructure_Update(this Broker broker, PString arg) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_GlobalStructure_Update, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_GlobalStructure_Update, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_GlobalStructure_Update(this Broker broker, PString arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_GlobalStructure_Update, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_GlobalStructure_Update, arg, ct);
 		}
 		
 		public async static Task<bool> Request_GlobalStructure_Update(this Broker broker, Timeouts timeoutSeconds, PString arg) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_GlobalStructure_Update, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_GlobalStructure_Update, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_GlobalStructure_Update(this Broker broker, Timeouts timeoutSeconds, PString arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_GlobalStructure_Update, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_GlobalStructure_Update, arg, ct);
 		}
 	
 		public async static Task<bool> Request_Structure_Touch(this Broker broker, Id arg) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_Structure_Touch, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_Structure_Touch, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_Structure_Touch(this Broker broker, Id arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_Structure_Touch, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_Structure_Touch, arg, ct);
 		}
 		
 		public async static Task<bool> Request_Structure_Touch(this Broker broker, Timeouts timeoutSeconds, Id arg) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_Structure_Touch, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_Structure_Touch, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_Structure_Touch(this Broker broker, Timeouts timeoutSeconds, Id arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_Structure_Touch, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_Structure_Touch, arg, ct);
 		}
 	
 		public async static Task<IdStructureBlockInfo> Request_Structure_BlockStatistics(this Broker broker, Id arg) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync<Id, IdStructureBlockInfo>(CmdId.Request_Structure_BlockStatistics, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<Id, IdStructureBlockInfo>(CmdId.Request_Structure_BlockStatistics, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(IdStructureBlockInfo);
+				}
 			}
 		}
 
 		public async static Task<IdStructureBlockInfo> Request_Structure_BlockStatistics(this Broker broker, Id arg, CancellationToken ct) {
-				return await broker.SendRequestAsync<Id, IdStructureBlockInfo>(CmdId.Request_Structure_BlockStatistics, arg, ct);
+			return await broker.SendRequestAsync<Id, IdStructureBlockInfo>(CmdId.Request_Structure_BlockStatistics, arg, ct);
 		}
 		
 		public async static Task<IdStructureBlockInfo> Request_Structure_BlockStatistics(this Broker broker, Timeouts timeoutSeconds, Id arg) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync<Id, IdStructureBlockInfo>(CmdId.Request_Structure_BlockStatistics, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<Id, IdStructureBlockInfo>(CmdId.Request_Structure_BlockStatistics, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(IdStructureBlockInfo);
+				}
 			}
 		}
 
 		public async static Task<IdStructureBlockInfo> Request_Structure_BlockStatistics(this Broker broker, Timeouts timeoutSeconds, Id arg, CancellationToken ct) {
-				return await broker.SendRequestAsync<Id, IdStructureBlockInfo>(CmdId.Request_Structure_BlockStatistics, arg, ct);
+			return await broker.SendRequestAsync<Id, IdStructureBlockInfo>(CmdId.Request_Structure_BlockStatistics, arg, ct);
 		}
 	
 		public async static Task<PlayerInfo> Request_Player_Info(this Broker broker, Id arg) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync<Id, PlayerInfo>(CmdId.Request_Player_Info, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<Id, PlayerInfo>(CmdId.Request_Player_Info, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(PlayerInfo);
+				}
 			}
 		}
 
 		public async static Task<PlayerInfo> Request_Player_Info(this Broker broker, Id arg, CancellationToken ct) {
-				return await broker.SendRequestAsync<Id, PlayerInfo>(CmdId.Request_Player_Info, arg, ct);
+			return await broker.SendRequestAsync<Id, PlayerInfo>(CmdId.Request_Player_Info, arg, ct);
 		}
 		
 		public async static Task<PlayerInfo> Request_Player_Info(this Broker broker, Timeouts timeoutSeconds, Id arg) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync<Id, PlayerInfo>(CmdId.Request_Player_Info, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<Id, PlayerInfo>(CmdId.Request_Player_Info, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(PlayerInfo);
+				}
 			}
 		}
 
 		public async static Task<PlayerInfo> Request_Player_Info(this Broker broker, Timeouts timeoutSeconds, Id arg, CancellationToken ct) {
-				return await broker.SendRequestAsync<Id, PlayerInfo>(CmdId.Request_Player_Info, arg, ct);
+			return await broker.SendRequestAsync<Id, PlayerInfo>(CmdId.Request_Player_Info, arg, ct);
 		}
 	
 		public async static Task<IdList> Request_Player_List(this Broker broker) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync<IdList>(CmdId.Request_Player_List, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<IdList>(CmdId.Request_Player_List, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(IdList);
+				}
 			}
 		}
 
 		public async static Task<IdList> Request_Player_List(this Broker broker, CancellationToken ct) {
-				return await broker.SendRequestAsync<IdList>(CmdId.Request_Player_List, ct);
+			return await broker.SendRequestAsync<IdList>(CmdId.Request_Player_List, ct);
 		}
 		
 		public async static Task<IdList> Request_Player_List(this Broker broker, Timeouts timeoutSeconds) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync<IdList>(CmdId.Request_Player_List, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<IdList>(CmdId.Request_Player_List, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(IdList);
+				}
 			}
 		}
 
 		public async static Task<IdList> Request_Player_List(this Broker broker, Timeouts timeoutSeconds, CancellationToken ct) {
-				return await broker.SendRequestAsync<IdList>(CmdId.Request_Player_List, ct);
+			return await broker.SendRequestAsync<IdList>(CmdId.Request_Player_List, ct);
 		}
 	
 		public async static Task<Inventory> Request_Player_GetInventory(this Broker broker, Id arg) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync<Id, Inventory>(CmdId.Request_Player_GetInventory, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<Id, Inventory>(CmdId.Request_Player_GetInventory, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(Inventory);
+				}
 			}
 		}
 
 		public async static Task<Inventory> Request_Player_GetInventory(this Broker broker, Id arg, CancellationToken ct) {
-				return await broker.SendRequestAsync<Id, Inventory>(CmdId.Request_Player_GetInventory, arg, ct);
+			return await broker.SendRequestAsync<Id, Inventory>(CmdId.Request_Player_GetInventory, arg, ct);
 		}
 		
 		public async static Task<Inventory> Request_Player_GetInventory(this Broker broker, Timeouts timeoutSeconds, Id arg) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync<Id, Inventory>(CmdId.Request_Player_GetInventory, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<Id, Inventory>(CmdId.Request_Player_GetInventory, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(Inventory);
+				}
 			}
 		}
 
 		public async static Task<Inventory> Request_Player_GetInventory(this Broker broker, Timeouts timeoutSeconds, Id arg, CancellationToken ct) {
-				return await broker.SendRequestAsync<Id, Inventory>(CmdId.Request_Player_GetInventory, arg, ct);
+			return await broker.SendRequestAsync<Id, Inventory>(CmdId.Request_Player_GetInventory, arg, ct);
 		}
 	
 		public async static Task<Inventory> Request_Player_SetInventory(this Broker broker, Inventory arg) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync<Inventory, Inventory>(CmdId.Request_Player_SetInventory, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<Inventory, Inventory>(CmdId.Request_Player_SetInventory, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(Inventory);
+				}
 			}
 		}
 
 		public async static Task<Inventory> Request_Player_SetInventory(this Broker broker, Inventory arg, CancellationToken ct) {
-				return await broker.SendRequestAsync<Inventory, Inventory>(CmdId.Request_Player_SetInventory, arg, ct);
+			return await broker.SendRequestAsync<Inventory, Inventory>(CmdId.Request_Player_SetInventory, arg, ct);
 		}
 		
 		public async static Task<Inventory> Request_Player_SetInventory(this Broker broker, Timeouts timeoutSeconds, Inventory arg) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync<Inventory, Inventory>(CmdId.Request_Player_SetInventory, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<Inventory, Inventory>(CmdId.Request_Player_SetInventory, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(Inventory);
+				}
 			}
 		}
 
 		public async static Task<Inventory> Request_Player_SetInventory(this Broker broker, Timeouts timeoutSeconds, Inventory arg, CancellationToken ct) {
-				return await broker.SendRequestAsync<Inventory, Inventory>(CmdId.Request_Player_SetInventory, arg, ct);
+			return await broker.SendRequestAsync<Inventory, Inventory>(CmdId.Request_Player_SetInventory, arg, ct);
 		}
 	
 		public async static Task<bool> Request_Player_AddItem(this Broker broker, IdItemStack arg) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_Player_AddItem, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_Player_AddItem, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_Player_AddItem(this Broker broker, IdItemStack arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_Player_AddItem, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_Player_AddItem, arg, ct);
 		}
 		
 		public async static Task<bool> Request_Player_AddItem(this Broker broker, Timeouts timeoutSeconds, IdItemStack arg) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_Player_AddItem, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_Player_AddItem, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_Player_AddItem(this Broker broker, Timeouts timeoutSeconds, IdItemStack arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_Player_AddItem, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_Player_AddItem, arg, ct);
 		}
 	
 		public async static Task<IdCredits> Request_Player_Credits(this Broker broker, Id arg) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync<Id, IdCredits>(CmdId.Request_Player_Credits, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<Id, IdCredits>(CmdId.Request_Player_Credits, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(IdCredits);
+				}
 			}
 		}
 
 		public async static Task<IdCredits> Request_Player_Credits(this Broker broker, Id arg, CancellationToken ct) {
-				return await broker.SendRequestAsync<Id, IdCredits>(CmdId.Request_Player_Credits, arg, ct);
+			return await broker.SendRequestAsync<Id, IdCredits>(CmdId.Request_Player_Credits, arg, ct);
 		}
 		
 		public async static Task<IdCredits> Request_Player_Credits(this Broker broker, Timeouts timeoutSeconds, Id arg) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync<Id, IdCredits>(CmdId.Request_Player_Credits, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<Id, IdCredits>(CmdId.Request_Player_Credits, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(IdCredits);
+				}
 			}
 		}
 
 		public async static Task<IdCredits> Request_Player_Credits(this Broker broker, Timeouts timeoutSeconds, Id arg, CancellationToken ct) {
-				return await broker.SendRequestAsync<Id, IdCredits>(CmdId.Request_Player_Credits, arg, ct);
+			return await broker.SendRequestAsync<Id, IdCredits>(CmdId.Request_Player_Credits, arg, ct);
 		}
 	
 		public async static Task<IdCredits> Request_Player_SetCredits(this Broker broker, IdCredits arg) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync<IdCredits, IdCredits>(CmdId.Request_Player_SetCredits, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<IdCredits, IdCredits>(CmdId.Request_Player_SetCredits, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(IdCredits);
+				}
 			}
 		}
 
 		public async static Task<IdCredits> Request_Player_SetCredits(this Broker broker, IdCredits arg, CancellationToken ct) {
-				return await broker.SendRequestAsync<IdCredits, IdCredits>(CmdId.Request_Player_SetCredits, arg, ct);
+			return await broker.SendRequestAsync<IdCredits, IdCredits>(CmdId.Request_Player_SetCredits, arg, ct);
 		}
 		
 		public async static Task<IdCredits> Request_Player_SetCredits(this Broker broker, Timeouts timeoutSeconds, IdCredits arg) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync<IdCredits, IdCredits>(CmdId.Request_Player_SetCredits, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<IdCredits, IdCredits>(CmdId.Request_Player_SetCredits, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(IdCredits);
+				}
 			}
 		}
 
 		public async static Task<IdCredits> Request_Player_SetCredits(this Broker broker, Timeouts timeoutSeconds, IdCredits arg, CancellationToken ct) {
-				return await broker.SendRequestAsync<IdCredits, IdCredits>(CmdId.Request_Player_SetCredits, arg, ct);
+			return await broker.SendRequestAsync<IdCredits, IdCredits>(CmdId.Request_Player_SetCredits, arg, ct);
 		}
 	
 		public async static Task<IdCredits> Request_Player_AddCredits(this Broker broker, IdCredits arg) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync<IdCredits, IdCredits>(CmdId.Request_Player_AddCredits, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<IdCredits, IdCredits>(CmdId.Request_Player_AddCredits, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(IdCredits);
+				}
 			}
 		}
 
 		public async static Task<IdCredits> Request_Player_AddCredits(this Broker broker, IdCredits arg, CancellationToken ct) {
-				return await broker.SendRequestAsync<IdCredits, IdCredits>(CmdId.Request_Player_AddCredits, arg, ct);
+			return await broker.SendRequestAsync<IdCredits, IdCredits>(CmdId.Request_Player_AddCredits, arg, ct);
 		}
 		
 		public async static Task<IdCredits> Request_Player_AddCredits(this Broker broker, Timeouts timeoutSeconds, IdCredits arg) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync<IdCredits, IdCredits>(CmdId.Request_Player_AddCredits, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<IdCredits, IdCredits>(CmdId.Request_Player_AddCredits, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(IdCredits);
+				}
 			}
 		}
 
 		public async static Task<IdCredits> Request_Player_AddCredits(this Broker broker, Timeouts timeoutSeconds, IdCredits arg, CancellationToken ct) {
-				return await broker.SendRequestAsync<IdCredits, IdCredits>(CmdId.Request_Player_AddCredits, arg, ct);
+			return await broker.SendRequestAsync<IdCredits, IdCredits>(CmdId.Request_Player_AddCredits, arg, ct);
 		}
 	
 		public async static Task<bool> Request_Blueprint_Finish(this Broker broker, Id arg) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_Blueprint_Finish, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_Blueprint_Finish, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_Blueprint_Finish(this Broker broker, Id arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_Blueprint_Finish, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_Blueprint_Finish, arg, ct);
 		}
 		
 		public async static Task<bool> Request_Blueprint_Finish(this Broker broker, Timeouts timeoutSeconds, Id arg) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_Blueprint_Finish, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_Blueprint_Finish, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_Blueprint_Finish(this Broker broker, Timeouts timeoutSeconds, Id arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_Blueprint_Finish, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_Blueprint_Finish, arg, ct);
 		}
 	
 		public async static Task<bool> Request_Blueprint_Resources(this Broker broker, BlueprintResources arg) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_Blueprint_Resources, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_Blueprint_Resources, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_Blueprint_Resources(this Broker broker, BlueprintResources arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_Blueprint_Resources, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_Blueprint_Resources, arg, ct);
 		}
 		
 		public async static Task<bool> Request_Blueprint_Resources(this Broker broker, Timeouts timeoutSeconds, BlueprintResources arg) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_Blueprint_Resources, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_Blueprint_Resources, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_Blueprint_Resources(this Broker broker, Timeouts timeoutSeconds, BlueprintResources arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_Blueprint_Resources, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_Blueprint_Resources, arg, ct);
 		}
 	
 		public async static Task<bool> Request_Player_ChangePlayerfield(this Broker broker, IdPlayfieldPositionRotation arg) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_Player_ChangePlayerfield, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_Player_ChangePlayerfield, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_Player_ChangePlayerfield(this Broker broker, IdPlayfieldPositionRotation arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_Player_ChangePlayerfield, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_Player_ChangePlayerfield, arg, ct);
 		}
 		
 		public async static Task<bool> Request_Player_ChangePlayerfield(this Broker broker, Timeouts timeoutSeconds, IdPlayfieldPositionRotation arg) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_Player_ChangePlayerfield, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_Player_ChangePlayerfield, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_Player_ChangePlayerfield(this Broker broker, Timeouts timeoutSeconds, IdPlayfieldPositionRotation arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_Player_ChangePlayerfield, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_Player_ChangePlayerfield, arg, ct);
 		}
 	
 		public async static Task<ItemExchangeInfo> Request_Player_ItemExchange(this Broker broker, ItemExchangeInfo arg) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync<ItemExchangeInfo, ItemExchangeInfo>(CmdId.Request_Player_ItemExchange, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<ItemExchangeInfo, ItemExchangeInfo>(CmdId.Request_Player_ItemExchange, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(ItemExchangeInfo);
+				}
 			}
 		}
 
 		public async static Task<ItemExchangeInfo> Request_Player_ItemExchange(this Broker broker, ItemExchangeInfo arg, CancellationToken ct) {
-				return await broker.SendRequestAsync<ItemExchangeInfo, ItemExchangeInfo>(CmdId.Request_Player_ItemExchange, arg, ct);
+			return await broker.SendRequestAsync<ItemExchangeInfo, ItemExchangeInfo>(CmdId.Request_Player_ItemExchange, arg, ct);
 		}
 		
 		public async static Task<ItemExchangeInfo> Request_Player_ItemExchange(this Broker broker, Timeouts timeoutSeconds, ItemExchangeInfo arg) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync<ItemExchangeInfo, ItemExchangeInfo>(CmdId.Request_Player_ItemExchange, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<ItemExchangeInfo, ItemExchangeInfo>(CmdId.Request_Player_ItemExchange, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(ItemExchangeInfo);
+				}
 			}
 		}
 
 		public async static Task<ItemExchangeInfo> Request_Player_ItemExchange(this Broker broker, Timeouts timeoutSeconds, ItemExchangeInfo arg, CancellationToken ct) {
-				return await broker.SendRequestAsync<ItemExchangeInfo, ItemExchangeInfo>(CmdId.Request_Player_ItemExchange, arg, ct);
+			return await broker.SendRequestAsync<ItemExchangeInfo, ItemExchangeInfo>(CmdId.Request_Player_ItemExchange, arg, ct);
 		}
 	
 		public async static Task<bool> Request_Player_SetPlayerInfo(this Broker broker, PlayerInfoSet arg) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_Player_SetPlayerInfo, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_Player_SetPlayerInfo, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_Player_SetPlayerInfo(this Broker broker, PlayerInfoSet arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_Player_SetPlayerInfo, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_Player_SetPlayerInfo, arg, ct);
 		}
 		
 		public async static Task<bool> Request_Player_SetPlayerInfo(this Broker broker, Timeouts timeoutSeconds, PlayerInfoSet arg) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_Player_SetPlayerInfo, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_Player_SetPlayerInfo, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_Player_SetPlayerInfo(this Broker broker, Timeouts timeoutSeconds, PlayerInfoSet arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_Player_SetPlayerInfo, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_Player_SetPlayerInfo, arg, ct);
 		}
 	
 		public async static Task<bool> Request_Entity_Teleport(this Broker broker, IdPositionRotation arg) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_Entity_Teleport, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_Entity_Teleport, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_Entity_Teleport(this Broker broker, IdPositionRotation arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_Entity_Teleport, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_Entity_Teleport, arg, ct);
 		}
 		
 		public async static Task<bool> Request_Entity_Teleport(this Broker broker, Timeouts timeoutSeconds, IdPositionRotation arg) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_Entity_Teleport, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_Entity_Teleport, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_Entity_Teleport(this Broker broker, Timeouts timeoutSeconds, IdPositionRotation arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_Entity_Teleport, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_Entity_Teleport, arg, ct);
 		}
 	
 		public async static Task<bool> Request_Entity_ChangePlayfield(this Broker broker, IdPlayfieldPositionRotation arg) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_Entity_ChangePlayfield, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_Entity_ChangePlayfield, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_Entity_ChangePlayfield(this Broker broker, IdPlayfieldPositionRotation arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_Entity_ChangePlayfield, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_Entity_ChangePlayfield, arg, ct);
 		}
 		
 		public async static Task<bool> Request_Entity_ChangePlayfield(this Broker broker, Timeouts timeoutSeconds, IdPlayfieldPositionRotation arg) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_Entity_ChangePlayfield, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_Entity_ChangePlayfield, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_Entity_ChangePlayfield(this Broker broker, Timeouts timeoutSeconds, IdPlayfieldPositionRotation arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_Entity_ChangePlayfield, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_Entity_ChangePlayfield, arg, ct);
 		}
 	
 		public async static Task<bool> Request_Entity_Destroy(this Broker broker, Id arg) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_Entity_Destroy, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_Entity_Destroy, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_Entity_Destroy(this Broker broker, Id arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_Entity_Destroy, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_Entity_Destroy, arg, ct);
 		}
 		
 		public async static Task<bool> Request_Entity_Destroy(this Broker broker, Timeouts timeoutSeconds, Id arg) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_Entity_Destroy, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_Entity_Destroy, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_Entity_Destroy(this Broker broker, Timeouts timeoutSeconds, Id arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_Entity_Destroy, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_Entity_Destroy, arg, ct);
 		}
 	
 		public async static Task<IdPositionRotation> Request_Entity_PosAndRot(this Broker broker, Id arg) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync<Id, IdPositionRotation>(CmdId.Request_Entity_PosAndRot, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<Id, IdPositionRotation>(CmdId.Request_Entity_PosAndRot, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(IdPositionRotation);
+				}
 			}
 		}
 
 		public async static Task<IdPositionRotation> Request_Entity_PosAndRot(this Broker broker, Id arg, CancellationToken ct) {
-				return await broker.SendRequestAsync<Id, IdPositionRotation>(CmdId.Request_Entity_PosAndRot, arg, ct);
+			return await broker.SendRequestAsync<Id, IdPositionRotation>(CmdId.Request_Entity_PosAndRot, arg, ct);
 		}
 		
 		public async static Task<IdPositionRotation> Request_Entity_PosAndRot(this Broker broker, Timeouts timeoutSeconds, Id arg) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync<Id, IdPositionRotation>(CmdId.Request_Entity_PosAndRot, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<Id, IdPositionRotation>(CmdId.Request_Entity_PosAndRot, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(IdPositionRotation);
+				}
 			}
 		}
 
 		public async static Task<IdPositionRotation> Request_Entity_PosAndRot(this Broker broker, Timeouts timeoutSeconds, Id arg, CancellationToken ct) {
-				return await broker.SendRequestAsync<Id, IdPositionRotation>(CmdId.Request_Entity_PosAndRot, arg, ct);
+			return await broker.SendRequestAsync<Id, IdPositionRotation>(CmdId.Request_Entity_PosAndRot, arg, ct);
 		}
 	
 		public async static Task<bool> Request_Entity_Spawn(this Broker broker, EntitySpawnInfo arg) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_Entity_Spawn, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_Entity_Spawn, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_Entity_Spawn(this Broker broker, EntitySpawnInfo arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_Entity_Spawn, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_Entity_Spawn, arg, ct);
 		}
 		
 		public async static Task<bool> Request_Entity_Spawn(this Broker broker, Timeouts timeoutSeconds, EntitySpawnInfo arg) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_Entity_Spawn, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_Entity_Spawn, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_Entity_Spawn(this Broker broker, Timeouts timeoutSeconds, EntitySpawnInfo arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_Entity_Spawn, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_Entity_Spawn, arg, ct);
 		}
 	
 		public async static Task<FactionInfoList> Request_Get_Factions(this Broker broker, Id arg) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync<Id, FactionInfoList>(CmdId.Request_Get_Factions, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<Id, FactionInfoList>(CmdId.Request_Get_Factions, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(FactionInfoList);
+				}
 			}
 		}
 
 		public async static Task<FactionInfoList> Request_Get_Factions(this Broker broker, Id arg, CancellationToken ct) {
-				return await broker.SendRequestAsync<Id, FactionInfoList>(CmdId.Request_Get_Factions, arg, ct);
+			return await broker.SendRequestAsync<Id, FactionInfoList>(CmdId.Request_Get_Factions, arg, ct);
 		}
 		
 		public async static Task<FactionInfoList> Request_Get_Factions(this Broker broker, Timeouts timeoutSeconds, Id arg) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync<Id, FactionInfoList>(CmdId.Request_Get_Factions, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<Id, FactionInfoList>(CmdId.Request_Get_Factions, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(FactionInfoList);
+				}
 			}
 		}
 
 		public async static Task<FactionInfoList> Request_Get_Factions(this Broker broker, Timeouts timeoutSeconds, Id arg, CancellationToken ct) {
-				return await broker.SendRequestAsync<Id, FactionInfoList>(CmdId.Request_Get_Factions, arg, ct);
+			return await broker.SendRequestAsync<Id, FactionInfoList>(CmdId.Request_Get_Factions, arg, ct);
 		}
 	
 		public async static Task<Id> Request_NewEntityId(this Broker broker) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync<Id>(CmdId.Request_NewEntityId, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<Id>(CmdId.Request_NewEntityId, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(Id);
+				}
 			}
 		}
 
 		public async static Task<Id> Request_NewEntityId(this Broker broker, CancellationToken ct) {
-				return await broker.SendRequestAsync<Id>(CmdId.Request_NewEntityId, ct);
+			return await broker.SendRequestAsync<Id>(CmdId.Request_NewEntityId, ct);
 		}
 		
 		public async static Task<Id> Request_NewEntityId(this Broker broker, Timeouts timeoutSeconds) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync<Id>(CmdId.Request_NewEntityId, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<Id>(CmdId.Request_NewEntityId, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(Id);
+				}
 			}
 		}
 
 		public async static Task<Id> Request_NewEntityId(this Broker broker, Timeouts timeoutSeconds, CancellationToken ct) {
-				return await broker.SendRequestAsync<Id>(CmdId.Request_NewEntityId, ct);
+			return await broker.SendRequestAsync<Id>(CmdId.Request_NewEntityId, ct);
 		}
 	
 		public async static Task<AlliancesTable> Request_AlliancesAll(this Broker broker) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync<AlliancesTable>(CmdId.Request_AlliancesAll, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<AlliancesTable>(CmdId.Request_AlliancesAll, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(AlliancesTable);
+				}
 			}
 		}
 
 		public async static Task<AlliancesTable> Request_AlliancesAll(this Broker broker, CancellationToken ct) {
-				return await broker.SendRequestAsync<AlliancesTable>(CmdId.Request_AlliancesAll, ct);
+			return await broker.SendRequestAsync<AlliancesTable>(CmdId.Request_AlliancesAll, ct);
 		}
 		
 		public async static Task<AlliancesTable> Request_AlliancesAll(this Broker broker, Timeouts timeoutSeconds) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync<AlliancesTable>(CmdId.Request_AlliancesAll, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<AlliancesTable>(CmdId.Request_AlliancesAll, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(AlliancesTable);
+				}
 			}
 		}
 
 		public async static Task<AlliancesTable> Request_AlliancesAll(this Broker broker, Timeouts timeoutSeconds, CancellationToken ct) {
-				return await broker.SendRequestAsync<AlliancesTable>(CmdId.Request_AlliancesAll, ct);
+			return await broker.SendRequestAsync<AlliancesTable>(CmdId.Request_AlliancesAll, ct);
 		}
 	
 		public async static Task<AlliancesFaction> Request_AlliancesFaction(this Broker broker, AlliancesFaction arg) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync<AlliancesFaction, AlliancesFaction>(CmdId.Request_AlliancesFaction, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<AlliancesFaction, AlliancesFaction>(CmdId.Request_AlliancesFaction, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(AlliancesFaction);
+				}
 			}
 		}
 
 		public async static Task<AlliancesFaction> Request_AlliancesFaction(this Broker broker, AlliancesFaction arg, CancellationToken ct) {
-				return await broker.SendRequestAsync<AlliancesFaction, AlliancesFaction>(CmdId.Request_AlliancesFaction, arg, ct);
+			return await broker.SendRequestAsync<AlliancesFaction, AlliancesFaction>(CmdId.Request_AlliancesFaction, arg, ct);
 		}
 		
 		public async static Task<AlliancesFaction> Request_AlliancesFaction(this Broker broker, Timeouts timeoutSeconds, AlliancesFaction arg) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync<AlliancesFaction, AlliancesFaction>(CmdId.Request_AlliancesFaction, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<AlliancesFaction, AlliancesFaction>(CmdId.Request_AlliancesFaction, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(AlliancesFaction);
+				}
 			}
 		}
 
 		public async static Task<AlliancesFaction> Request_AlliancesFaction(this Broker broker, Timeouts timeoutSeconds, AlliancesFaction arg, CancellationToken ct) {
-				return await broker.SendRequestAsync<AlliancesFaction, AlliancesFaction>(CmdId.Request_AlliancesFaction, arg, ct);
+			return await broker.SendRequestAsync<AlliancesFaction, AlliancesFaction>(CmdId.Request_AlliancesFaction, arg, ct);
 		}
 	
 		public async static Task<bool> Request_Load_Playfield(this Broker broker, PlayfieldLoad arg) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_Load_Playfield, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_Load_Playfield, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_Load_Playfield(this Broker broker, PlayfieldLoad arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_Load_Playfield, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_Load_Playfield, arg, ct);
 		}
 		
 		public async static Task<bool> Request_Load_Playfield(this Broker broker, Timeouts timeoutSeconds, PlayfieldLoad arg) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_Load_Playfield, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_Load_Playfield, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_Load_Playfield(this Broker broker, Timeouts timeoutSeconds, PlayfieldLoad arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_Load_Playfield, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_Load_Playfield, arg, ct);
 		}
 	
 		public async static Task<bool> Request_ConsoleCommand(this Broker broker, PString arg) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_ConsoleCommand, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_ConsoleCommand, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_ConsoleCommand(this Broker broker, PString arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_ConsoleCommand, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_ConsoleCommand, arg, ct);
 		}
 		
 		public async static Task<bool> Request_ConsoleCommand(this Broker broker, Timeouts timeoutSeconds, PString arg) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_ConsoleCommand, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_ConsoleCommand, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_ConsoleCommand(this Broker broker, Timeouts timeoutSeconds, PString arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_ConsoleCommand, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_ConsoleCommand, arg, ct);
 		}
 	
 		public async static Task<IdList> Request_GetBannedPlayers(this Broker broker) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync<IdList>(CmdId.Request_GetBannedPlayers, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<IdList>(CmdId.Request_GetBannedPlayers, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(IdList);
+				}
 			}
 		}
 
 		public async static Task<IdList> Request_GetBannedPlayers(this Broker broker, CancellationToken ct) {
-				return await broker.SendRequestAsync<IdList>(CmdId.Request_GetBannedPlayers, ct);
+			return await broker.SendRequestAsync<IdList>(CmdId.Request_GetBannedPlayers, ct);
 		}
 		
 		public async static Task<IdList> Request_GetBannedPlayers(this Broker broker, Timeouts timeoutSeconds) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync<IdList>(CmdId.Request_GetBannedPlayers, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<IdList>(CmdId.Request_GetBannedPlayers, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(IdList);
+				}
 			}
 		}
 
 		public async static Task<IdList> Request_GetBannedPlayers(this Broker broker, Timeouts timeoutSeconds, CancellationToken ct) {
-				return await broker.SendRequestAsync<IdList>(CmdId.Request_GetBannedPlayers, ct);
+			return await broker.SendRequestAsync<IdList>(CmdId.Request_GetBannedPlayers, ct);
 		}
 	
 		public async static Task<bool> Request_InGameMessage_SinglePlayer(this Broker broker, IdMsgPrio arg) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_InGameMessage_SinglePlayer, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_InGameMessage_SinglePlayer, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_InGameMessage_SinglePlayer(this Broker broker, IdMsgPrio arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_InGameMessage_SinglePlayer, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_InGameMessage_SinglePlayer, arg, ct);
 		}
 		
 		public async static Task<bool> Request_InGameMessage_SinglePlayer(this Broker broker, Timeouts timeoutSeconds, IdMsgPrio arg) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_InGameMessage_SinglePlayer, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_InGameMessage_SinglePlayer, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_InGameMessage_SinglePlayer(this Broker broker, Timeouts timeoutSeconds, IdMsgPrio arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_InGameMessage_SinglePlayer, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_InGameMessage_SinglePlayer, arg, ct);
 		}
 	
 		public async static Task<bool> Request_InGameMessage_AllPlayers(this Broker broker, IdMsgPrio arg) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_InGameMessage_AllPlayers, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_InGameMessage_AllPlayers, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_InGameMessage_AllPlayers(this Broker broker, IdMsgPrio arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_InGameMessage_AllPlayers, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_InGameMessage_AllPlayers, arg, ct);
 		}
 		
 		public async static Task<bool> Request_InGameMessage_AllPlayers(this Broker broker, Timeouts timeoutSeconds, IdMsgPrio arg) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_InGameMessage_AllPlayers, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_InGameMessage_AllPlayers, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_InGameMessage_AllPlayers(this Broker broker, Timeouts timeoutSeconds, IdMsgPrio arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_InGameMessage_AllPlayers, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_InGameMessage_AllPlayers, arg, ct);
 		}
 	
 		public async static Task<bool> Request_InGameMessage_Faction(this Broker broker, IdMsgPrio arg) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_InGameMessage_Faction, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_InGameMessage_Faction, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_InGameMessage_Faction(this Broker broker, IdMsgPrio arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_InGameMessage_Faction, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_InGameMessage_Faction, arg, ct);
 		}
 		
 		public async static Task<bool> Request_InGameMessage_Faction(this Broker broker, Timeouts timeoutSeconds, IdMsgPrio arg) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_InGameMessage_Faction, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_InGameMessage_Faction, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_InGameMessage_Faction(this Broker broker, Timeouts timeoutSeconds, IdMsgPrio arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_InGameMessage_Faction, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_InGameMessage_Faction, arg, ct);
 		}
 	
 		public async static Task<IdAndIntValue> Request_ShowDialog_SinglePlayer(this Broker broker, DialogBoxData arg) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync<DialogBoxData, IdAndIntValue>(CmdId.Request_ShowDialog_SinglePlayer, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<DialogBoxData, IdAndIntValue>(CmdId.Request_ShowDialog_SinglePlayer, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(IdAndIntValue);
+				}
 			}
 		}
 
 		public async static Task<IdAndIntValue> Request_ShowDialog_SinglePlayer(this Broker broker, DialogBoxData arg, CancellationToken ct) {
-				return await broker.SendRequestAsync<DialogBoxData, IdAndIntValue>(CmdId.Request_ShowDialog_SinglePlayer, arg, ct);
+			return await broker.SendRequestAsync<DialogBoxData, IdAndIntValue>(CmdId.Request_ShowDialog_SinglePlayer, arg, ct);
 		}
 		
 		public async static Task<IdAndIntValue> Request_ShowDialog_SinglePlayer(this Broker broker, Timeouts timeoutSeconds, DialogBoxData arg) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync<DialogBoxData, IdAndIntValue>(CmdId.Request_ShowDialog_SinglePlayer, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<DialogBoxData, IdAndIntValue>(CmdId.Request_ShowDialog_SinglePlayer, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(IdAndIntValue);
+				}
 			}
 		}
 
 		public async static Task<IdAndIntValue> Request_ShowDialog_SinglePlayer(this Broker broker, Timeouts timeoutSeconds, DialogBoxData arg, CancellationToken ct) {
-				return await broker.SendRequestAsync<DialogBoxData, IdAndIntValue>(CmdId.Request_ShowDialog_SinglePlayer, arg, ct);
+			return await broker.SendRequestAsync<DialogBoxData, IdAndIntValue>(CmdId.Request_ShowDialog_SinglePlayer, arg, ct);
 		}
 	
 		public async static Task<Inventory> Request_Player_GetAndRemoveInventory(this Broker broker, Id arg) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync<Id, Inventory>(CmdId.Request_Player_GetAndRemoveInventory, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<Id, Inventory>(CmdId.Request_Player_GetAndRemoveInventory, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(Inventory);
+				}
 			}
 		}
 
 		public async static Task<Inventory> Request_Player_GetAndRemoveInventory(this Broker broker, Id arg, CancellationToken ct) {
-				return await broker.SendRequestAsync<Id, Inventory>(CmdId.Request_Player_GetAndRemoveInventory, arg, ct);
+			return await broker.SendRequestAsync<Id, Inventory>(CmdId.Request_Player_GetAndRemoveInventory, arg, ct);
 		}
 		
 		public async static Task<Inventory> Request_Player_GetAndRemoveInventory(this Broker broker, Timeouts timeoutSeconds, Id arg) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync<Id, Inventory>(CmdId.Request_Player_GetAndRemoveInventory, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<Id, Inventory>(CmdId.Request_Player_GetAndRemoveInventory, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(Inventory);
+				}
 			}
 		}
 
 		public async static Task<Inventory> Request_Player_GetAndRemoveInventory(this Broker broker, Timeouts timeoutSeconds, Id arg, CancellationToken ct) {
-				return await broker.SendRequestAsync<Id, Inventory>(CmdId.Request_Player_GetAndRemoveInventory, arg, ct);
+			return await broker.SendRequestAsync<Id, Inventory>(CmdId.Request_Player_GetAndRemoveInventory, arg, ct);
 		}
 	
 		public async static Task<PlayfieldEntityList> Request_Playfield_Entity_List(this Broker broker, PString arg) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync<PString, PlayfieldEntityList>(CmdId.Request_Playfield_Entity_List, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<PString, PlayfieldEntityList>(CmdId.Request_Playfield_Entity_List, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(PlayfieldEntityList);
+				}
 			}
 		}
 
 		public async static Task<PlayfieldEntityList> Request_Playfield_Entity_List(this Broker broker, PString arg, CancellationToken ct) {
-				return await broker.SendRequestAsync<PString, PlayfieldEntityList>(CmdId.Request_Playfield_Entity_List, arg, ct);
+			return await broker.SendRequestAsync<PString, PlayfieldEntityList>(CmdId.Request_Playfield_Entity_List, arg, ct);
 		}
 		
 		public async static Task<PlayfieldEntityList> Request_Playfield_Entity_List(this Broker broker, Timeouts timeoutSeconds, PString arg) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync<PString, PlayfieldEntityList>(CmdId.Request_Playfield_Entity_List, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync<PString, PlayfieldEntityList>(CmdId.Request_Playfield_Entity_List, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(PlayfieldEntityList);
+				}
 			}
 		}
 
 		public async static Task<PlayfieldEntityList> Request_Playfield_Entity_List(this Broker broker, Timeouts timeoutSeconds, PString arg, CancellationToken ct) {
-				return await broker.SendRequestAsync<PString, PlayfieldEntityList>(CmdId.Request_Playfield_Entity_List, arg, ct);
+			return await broker.SendRequestAsync<PString, PlayfieldEntityList>(CmdId.Request_Playfield_Entity_List, arg, ct);
 		}
 	
 		public async static Task<bool> Request_Entity_Destroy2(this Broker broker, IdPlayfield arg) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_Entity_Destroy2, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_Entity_Destroy2, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_Entity_Destroy2(this Broker broker, IdPlayfield arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_Entity_Destroy2, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_Entity_Destroy2, arg, ct);
 		}
 		
 		public async static Task<bool> Request_Entity_Destroy2(this Broker broker, Timeouts timeoutSeconds, IdPlayfield arg) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_Entity_Destroy2, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_Entity_Destroy2, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_Entity_Destroy2(this Broker broker, Timeouts timeoutSeconds, IdPlayfield arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_Entity_Destroy2, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_Entity_Destroy2, arg, ct);
 		}
 	
 		public async static Task<bool> Request_Entity_Export(this Broker broker, EntityExportInfo arg) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_Entity_Export, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_Entity_Export, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_Entity_Export(this Broker broker, EntityExportInfo arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_Entity_Export, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_Entity_Export, arg, ct);
 		}
 		
 		public async static Task<bool> Request_Entity_Export(this Broker broker, Timeouts timeoutSeconds, EntityExportInfo arg) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_Entity_Export, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_Entity_Export, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_Entity_Export(this Broker broker, Timeouts timeoutSeconds, EntityExportInfo arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_Entity_Export, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_Entity_Export, arg, ct);
 		}
 	
 		public async static Task<bool> Request_Entity_SetName(this Broker broker, IdPlayfieldName arg) {
 			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_Entity_SetName, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_Entity_SetName, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_Entity_SetName(this Broker broker, IdPlayfieldName arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_Entity_SetName, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_Entity_SetName, arg, ct);
 		}
 		
 		public async static Task<bool> Request_Entity_SetName(this Broker broker, Timeouts timeoutSeconds, IdPlayfieldName arg) {
 			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
 			{
-				return await broker.SendRequestAsync(CmdId.Request_Entity_SetName, arg, source.Token);
+				try
+				{
+					return await broker.SendRequestAsync(CmdId.Request_Entity_SetName, arg, source.Token);
+				}
+				catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+				{
+					return default(bool);
+				}
 			}
 		}
 
 		public async static Task<bool> Request_Entity_SetName(this Broker broker, Timeouts timeoutSeconds, IdPlayfieldName arg, CancellationToken ct) {
-				return await broker.SendRequestAsync(CmdId.Request_Entity_SetName, arg, ct);
+			return await broker.SendRequestAsync(CmdId.Request_Entity_SetName, arg, ct);
 		}
 	}
 }

--- a/EmpyrionNetAPIBroker/Autowire.Broker.APIRequestsDefinition.tt
+++ b/EmpyrionNetAPIBroker/Autowire.Broker.APIRequestsDefinition.tt
@@ -117,29 +117,35 @@ namespace EmpyrionNetAPIAccess
 		public string GetMethodBodyTemplate()
 		{
 			var sendRequestTemplate = GetSendRequestTemplateInfo("arg");
-			var timeoutTemplate = "EmpyrionRequestsDefaultTimeout";
 			var ctokenTimeoutTemplate = "EmpyrionRequestsDefaultTimeout.Milliseconds";
 			
 			if (HasArgWithName("timeoutSeconds"))			
 			{
-				timeoutTemplate = "(int)timeoutSeconds";
 				ctokenTimeoutTemplate = "(int)timeoutSeconds * 1000";
 			}
 
 			if (HasArgWithName("ct"))
 			{
 				return (returnType == null)
-						? string.Format("	return await broker.SendRequestAsync({1}, ct);", timeoutTemplate, sendRequestTemplate.ParametersTemplate)
-						: string.Format("	return await broker.SendRequestAsync<{1}>({2}, ct);", timeoutTemplate, sendRequestTemplate.GenericsTemplate, sendRequestTemplate.ParametersTemplate);
+						? string.Format("return await broker.SendRequestAsync({0}, ct);", sendRequestTemplate.ParametersTemplate)
+						: string.Format("return await broker.SendRequestAsync<{0}>({1}, ct);", sendRequestTemplate.GenericsTemplate, sendRequestTemplate.ParametersTemplate);
 			} 
 			else 
 			{				
 				return string.Join(string.Concat(Environment.NewLine, "			"), 
 					string.Format("using (var source = new CancellationTokenSource({0}))", ctokenTimeoutTemplate), 
 					"{",
-					(returnType == null)
-						? string.Format("	return await broker.SendRequestAsync({1}, source.Token);", timeoutTemplate, sendRequestTemplate.ParametersTemplate)
-						: string.Format("	return await broker.SendRequestAsync<{1}>({2}, source.Token);", timeoutTemplate, sendRequestTemplate.GenericsTemplate, sendRequestTemplate.ParametersTemplate),
+					string.Join(string.Concat(Environment.NewLine, "				"),
+						"	try",
+						"{",
+						(returnType == null)
+							? string.Format("	return await broker.SendRequestAsync({0}, source.Token);", sendRequestTemplate.ParametersTemplate)
+							: string.Format("	return await broker.SendRequestAsync<{0}>({1}, source.Token);", sendRequestTemplate.GenericsTemplate, sendRequestTemplate.ParametersTemplate),
+						"}",
+						"catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)",
+						"{",
+						string.Format("	return default({0});", returnType ?? "bool"), 
+						"}"),
 					"}");
 			}
 		}

--- a/EmpyrionNetAPIModBase/Autowire.ModBase.APIRequestsDefinition.cs
+++ b/EmpyrionNetAPIModBase/Autowire.ModBase.APIRequestsDefinition.cs
@@ -16,904 +16,330 @@ namespace EmpyrionNetAPIAccess
 		
 		
 		public async Task<PlayfieldList> Request_Playfield_List() {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync<PlayfieldList>(CmdId.Request_Playfield_List, source.Token);
-			}
+			return await Broker.SendRequestAsync<PlayfieldList>(CmdId.Request_Playfield_List);
 		}
 
 		public async Task<PlayfieldList> Request_Playfield_List(CancellationToken ct) {
 			return await Broker.SendRequestAsync<PlayfieldList>(CmdId.Request_Playfield_List, ct);
 		}
-		
-		public async Task<PlayfieldList> Request_Playfield_List(Timeouts timeoutSeconds) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync<PlayfieldList>(CmdId.Request_Playfield_List, source.Token);
-			}
-		}
-
-		public async Task<PlayfieldList> Request_Playfield_List(Timeouts timeoutSeconds, CancellationToken ct) {
-			return await Broker.SendRequestAsync<PlayfieldList>(CmdId.Request_Playfield_List, ct);
-		}
 	
 		public async Task<PlayfieldStats> Request_Playfield_Stats(PString arg) {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync<PString, PlayfieldStats>(CmdId.Request_Playfield_Stats, arg, source.Token);
-			}
+			return await Broker.SendRequestAsync<PString, PlayfieldStats>(CmdId.Request_Playfield_Stats, arg);
 		}
 
 		public async Task<PlayfieldStats> Request_Playfield_Stats(PString arg, CancellationToken ct) {
 			return await Broker.SendRequestAsync<PString, PlayfieldStats>(CmdId.Request_Playfield_Stats, arg, ct);
 		}
-		
-		public async Task<PlayfieldStats> Request_Playfield_Stats(Timeouts timeoutSeconds, PString arg) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync<PString, PlayfieldStats>(CmdId.Request_Playfield_Stats, arg, source.Token);
-			}
-		}
-
-		public async Task<PlayfieldStats> Request_Playfield_Stats(Timeouts timeoutSeconds, PString arg, CancellationToken ct) {
-			return await Broker.SendRequestAsync<PString, PlayfieldStats>(CmdId.Request_Playfield_Stats, arg, ct);
-		}
 	
 		public async Task<DediStats> Request_Dedi_Stats() {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync<DediStats>(CmdId.Request_Dedi_Stats, source.Token);
-			}
+			return await Broker.SendRequestAsync<DediStats>(CmdId.Request_Dedi_Stats);
 		}
 
 		public async Task<DediStats> Request_Dedi_Stats(CancellationToken ct) {
 			return await Broker.SendRequestAsync<DediStats>(CmdId.Request_Dedi_Stats, ct);
 		}
-		
-		public async Task<DediStats> Request_Dedi_Stats(Timeouts timeoutSeconds) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync<DediStats>(CmdId.Request_Dedi_Stats, source.Token);
-			}
-		}
-
-		public async Task<DediStats> Request_Dedi_Stats(Timeouts timeoutSeconds, CancellationToken ct) {
-			return await Broker.SendRequestAsync<DediStats>(CmdId.Request_Dedi_Stats, ct);
-		}
 	
 		public async Task<GlobalStructureList> Request_GlobalStructure_List() {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync<GlobalStructureList>(CmdId.Request_GlobalStructure_List, source.Token);
-			}
+			return await Broker.SendRequestAsync<GlobalStructureList>(CmdId.Request_GlobalStructure_List);
 		}
 
 		public async Task<GlobalStructureList> Request_GlobalStructure_List(CancellationToken ct) {
 			return await Broker.SendRequestAsync<GlobalStructureList>(CmdId.Request_GlobalStructure_List, ct);
 		}
-		
-		public async Task<GlobalStructureList> Request_GlobalStructure_List(Timeouts timeoutSeconds) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync<GlobalStructureList>(CmdId.Request_GlobalStructure_List, source.Token);
-			}
-		}
-
-		public async Task<GlobalStructureList> Request_GlobalStructure_List(Timeouts timeoutSeconds, CancellationToken ct) {
-			return await Broker.SendRequestAsync<GlobalStructureList>(CmdId.Request_GlobalStructure_List, ct);
-		}
 	
 		public async Task<bool> Request_GlobalStructure_Update(PString arg) {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_GlobalStructure_Update, arg, source.Token);
-			}
+			return await Broker.SendRequestAsync(CmdId.Request_GlobalStructure_Update, arg);
 		}
 
 		public async Task<bool> Request_GlobalStructure_Update(PString arg, CancellationToken ct) {
 			return await Broker.SendRequestAsync(CmdId.Request_GlobalStructure_Update, arg, ct);
 		}
-		
-		public async Task<bool> Request_GlobalStructure_Update(Timeouts timeoutSeconds, PString arg) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_GlobalStructure_Update, arg, source.Token);
-			}
-		}
-
-		public async Task<bool> Request_GlobalStructure_Update(Timeouts timeoutSeconds, PString arg, CancellationToken ct) {
-			return await Broker.SendRequestAsync(CmdId.Request_GlobalStructure_Update, arg, ct);
-		}
 	
 		public async Task<bool> Request_Structure_Touch(Id arg) {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_Structure_Touch, arg, source.Token);
-			}
+			return await Broker.SendRequestAsync(CmdId.Request_Structure_Touch, arg);
 		}
 
 		public async Task<bool> Request_Structure_Touch(Id arg, CancellationToken ct) {
 			return await Broker.SendRequestAsync(CmdId.Request_Structure_Touch, arg, ct);
 		}
-		
-		public async Task<bool> Request_Structure_Touch(Timeouts timeoutSeconds, Id arg) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_Structure_Touch, arg, source.Token);
-			}
-		}
-
-		public async Task<bool> Request_Structure_Touch(Timeouts timeoutSeconds, Id arg, CancellationToken ct) {
-			return await Broker.SendRequestAsync(CmdId.Request_Structure_Touch, arg, ct);
-		}
 	
 		public async Task<IdStructureBlockInfo> Request_Structure_BlockStatistics(Id arg) {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync<Id, IdStructureBlockInfo>(CmdId.Request_Structure_BlockStatistics, arg, source.Token);
-			}
+			return await Broker.SendRequestAsync<Id, IdStructureBlockInfo>(CmdId.Request_Structure_BlockStatistics, arg);
 		}
 
 		public async Task<IdStructureBlockInfo> Request_Structure_BlockStatistics(Id arg, CancellationToken ct) {
 			return await Broker.SendRequestAsync<Id, IdStructureBlockInfo>(CmdId.Request_Structure_BlockStatistics, arg, ct);
 		}
-		
-		public async Task<IdStructureBlockInfo> Request_Structure_BlockStatistics(Timeouts timeoutSeconds, Id arg) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync<Id, IdStructureBlockInfo>(CmdId.Request_Structure_BlockStatistics, arg, source.Token);
-			}
-		}
-
-		public async Task<IdStructureBlockInfo> Request_Structure_BlockStatistics(Timeouts timeoutSeconds, Id arg, CancellationToken ct) {
-			return await Broker.SendRequestAsync<Id, IdStructureBlockInfo>(CmdId.Request_Structure_BlockStatistics, arg, ct);
-		}
 	
 		public async Task<PlayerInfo> Request_Player_Info(Id arg) {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync<Id, PlayerInfo>(CmdId.Request_Player_Info, arg, source.Token);
-			}
+			return await Broker.SendRequestAsync<Id, PlayerInfo>(CmdId.Request_Player_Info, arg);
 		}
 
 		public async Task<PlayerInfo> Request_Player_Info(Id arg, CancellationToken ct) {
 			return await Broker.SendRequestAsync<Id, PlayerInfo>(CmdId.Request_Player_Info, arg, ct);
 		}
-		
-		public async Task<PlayerInfo> Request_Player_Info(Timeouts timeoutSeconds, Id arg) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync<Id, PlayerInfo>(CmdId.Request_Player_Info, arg, source.Token);
-			}
-		}
-
-		public async Task<PlayerInfo> Request_Player_Info(Timeouts timeoutSeconds, Id arg, CancellationToken ct) {
-			return await Broker.SendRequestAsync<Id, PlayerInfo>(CmdId.Request_Player_Info, arg, ct);
-		}
 	
 		public async Task<IdList> Request_Player_List() {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync<IdList>(CmdId.Request_Player_List, source.Token);
-			}
+			return await Broker.SendRequestAsync<IdList>(CmdId.Request_Player_List);
 		}
 
 		public async Task<IdList> Request_Player_List(CancellationToken ct) {
 			return await Broker.SendRequestAsync<IdList>(CmdId.Request_Player_List, ct);
 		}
-		
-		public async Task<IdList> Request_Player_List(Timeouts timeoutSeconds) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync<IdList>(CmdId.Request_Player_List, source.Token);
-			}
-		}
-
-		public async Task<IdList> Request_Player_List(Timeouts timeoutSeconds, CancellationToken ct) {
-			return await Broker.SendRequestAsync<IdList>(CmdId.Request_Player_List, ct);
-		}
 	
 		public async Task<Inventory> Request_Player_GetInventory(Id arg) {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync<Id, Inventory>(CmdId.Request_Player_GetInventory, arg, source.Token);
-			}
+			return await Broker.SendRequestAsync<Id, Inventory>(CmdId.Request_Player_GetInventory, arg);
 		}
 
 		public async Task<Inventory> Request_Player_GetInventory(Id arg, CancellationToken ct) {
 			return await Broker.SendRequestAsync<Id, Inventory>(CmdId.Request_Player_GetInventory, arg, ct);
 		}
-		
-		public async Task<Inventory> Request_Player_GetInventory(Timeouts timeoutSeconds, Id arg) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync<Id, Inventory>(CmdId.Request_Player_GetInventory, arg, source.Token);
-			}
-		}
-
-		public async Task<Inventory> Request_Player_GetInventory(Timeouts timeoutSeconds, Id arg, CancellationToken ct) {
-			return await Broker.SendRequestAsync<Id, Inventory>(CmdId.Request_Player_GetInventory, arg, ct);
-		}
 	
 		public async Task<Inventory> Request_Player_SetInventory(Inventory arg) {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync<Inventory, Inventory>(CmdId.Request_Player_SetInventory, arg, source.Token);
-			}
+			return await Broker.SendRequestAsync<Inventory, Inventory>(CmdId.Request_Player_SetInventory, arg);
 		}
 
 		public async Task<Inventory> Request_Player_SetInventory(Inventory arg, CancellationToken ct) {
 			return await Broker.SendRequestAsync<Inventory, Inventory>(CmdId.Request_Player_SetInventory, arg, ct);
 		}
-		
-		public async Task<Inventory> Request_Player_SetInventory(Timeouts timeoutSeconds, Inventory arg) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync<Inventory, Inventory>(CmdId.Request_Player_SetInventory, arg, source.Token);
-			}
-		}
-
-		public async Task<Inventory> Request_Player_SetInventory(Timeouts timeoutSeconds, Inventory arg, CancellationToken ct) {
-			return await Broker.SendRequestAsync<Inventory, Inventory>(CmdId.Request_Player_SetInventory, arg, ct);
-		}
 	
 		public async Task<bool> Request_Player_AddItem(IdItemStack arg) {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_Player_AddItem, arg, source.Token);
-			}
+			return await Broker.SendRequestAsync(CmdId.Request_Player_AddItem, arg);
 		}
 
 		public async Task<bool> Request_Player_AddItem(IdItemStack arg, CancellationToken ct) {
 			return await Broker.SendRequestAsync(CmdId.Request_Player_AddItem, arg, ct);
 		}
-		
-		public async Task<bool> Request_Player_AddItem(Timeouts timeoutSeconds, IdItemStack arg) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_Player_AddItem, arg, source.Token);
-			}
-		}
-
-		public async Task<bool> Request_Player_AddItem(Timeouts timeoutSeconds, IdItemStack arg, CancellationToken ct) {
-			return await Broker.SendRequestAsync(CmdId.Request_Player_AddItem, arg, ct);
-		}
 	
 		public async Task<IdCredits> Request_Player_Credits(Id arg) {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync<Id, IdCredits>(CmdId.Request_Player_Credits, arg, source.Token);
-			}
+			return await Broker.SendRequestAsync<Id, IdCredits>(CmdId.Request_Player_Credits, arg);
 		}
 
 		public async Task<IdCredits> Request_Player_Credits(Id arg, CancellationToken ct) {
 			return await Broker.SendRequestAsync<Id, IdCredits>(CmdId.Request_Player_Credits, arg, ct);
 		}
-		
-		public async Task<IdCredits> Request_Player_Credits(Timeouts timeoutSeconds, Id arg) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync<Id, IdCredits>(CmdId.Request_Player_Credits, arg, source.Token);
-			}
-		}
-
-		public async Task<IdCredits> Request_Player_Credits(Timeouts timeoutSeconds, Id arg, CancellationToken ct) {
-			return await Broker.SendRequestAsync<Id, IdCredits>(CmdId.Request_Player_Credits, arg, ct);
-		}
 	
 		public async Task<IdCredits> Request_Player_SetCredits(IdCredits arg) {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync<IdCredits, IdCredits>(CmdId.Request_Player_SetCredits, arg, source.Token);
-			}
+			return await Broker.SendRequestAsync<IdCredits, IdCredits>(CmdId.Request_Player_SetCredits, arg);
 		}
 
 		public async Task<IdCredits> Request_Player_SetCredits(IdCredits arg, CancellationToken ct) {
 			return await Broker.SendRequestAsync<IdCredits, IdCredits>(CmdId.Request_Player_SetCredits, arg, ct);
 		}
-		
-		public async Task<IdCredits> Request_Player_SetCredits(Timeouts timeoutSeconds, IdCredits arg) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync<IdCredits, IdCredits>(CmdId.Request_Player_SetCredits, arg, source.Token);
-			}
-		}
-
-		public async Task<IdCredits> Request_Player_SetCredits(Timeouts timeoutSeconds, IdCredits arg, CancellationToken ct) {
-			return await Broker.SendRequestAsync<IdCredits, IdCredits>(CmdId.Request_Player_SetCredits, arg, ct);
-		}
 	
 		public async Task<IdCredits> Request_Player_AddCredits(IdCredits arg) {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync<IdCredits, IdCredits>(CmdId.Request_Player_AddCredits, arg, source.Token);
-			}
+			return await Broker.SendRequestAsync<IdCredits, IdCredits>(CmdId.Request_Player_AddCredits, arg);
 		}
 
 		public async Task<IdCredits> Request_Player_AddCredits(IdCredits arg, CancellationToken ct) {
 			return await Broker.SendRequestAsync<IdCredits, IdCredits>(CmdId.Request_Player_AddCredits, arg, ct);
 		}
-		
-		public async Task<IdCredits> Request_Player_AddCredits(Timeouts timeoutSeconds, IdCredits arg) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync<IdCredits, IdCredits>(CmdId.Request_Player_AddCredits, arg, source.Token);
-			}
-		}
-
-		public async Task<IdCredits> Request_Player_AddCredits(Timeouts timeoutSeconds, IdCredits arg, CancellationToken ct) {
-			return await Broker.SendRequestAsync<IdCredits, IdCredits>(CmdId.Request_Player_AddCredits, arg, ct);
-		}
 	
 		public async Task<bool> Request_Blueprint_Finish(Id arg) {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_Blueprint_Finish, arg, source.Token);
-			}
+			return await Broker.SendRequestAsync(CmdId.Request_Blueprint_Finish, arg);
 		}
 
 		public async Task<bool> Request_Blueprint_Finish(Id arg, CancellationToken ct) {
 			return await Broker.SendRequestAsync(CmdId.Request_Blueprint_Finish, arg, ct);
 		}
-		
-		public async Task<bool> Request_Blueprint_Finish(Timeouts timeoutSeconds, Id arg) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_Blueprint_Finish, arg, source.Token);
-			}
-		}
-
-		public async Task<bool> Request_Blueprint_Finish(Timeouts timeoutSeconds, Id arg, CancellationToken ct) {
-			return await Broker.SendRequestAsync(CmdId.Request_Blueprint_Finish, arg, ct);
-		}
 	
 		public async Task<bool> Request_Blueprint_Resources(BlueprintResources arg) {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_Blueprint_Resources, arg, source.Token);
-			}
+			return await Broker.SendRequestAsync(CmdId.Request_Blueprint_Resources, arg);
 		}
 
 		public async Task<bool> Request_Blueprint_Resources(BlueprintResources arg, CancellationToken ct) {
 			return await Broker.SendRequestAsync(CmdId.Request_Blueprint_Resources, arg, ct);
 		}
-		
-		public async Task<bool> Request_Blueprint_Resources(Timeouts timeoutSeconds, BlueprintResources arg) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_Blueprint_Resources, arg, source.Token);
-			}
-		}
-
-		public async Task<bool> Request_Blueprint_Resources(Timeouts timeoutSeconds, BlueprintResources arg, CancellationToken ct) {
-			return await Broker.SendRequestAsync(CmdId.Request_Blueprint_Resources, arg, ct);
-		}
 	
 		public async Task<bool> Request_Player_ChangePlayerfield(IdPlayfieldPositionRotation arg) {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_Player_ChangePlayerfield, arg, source.Token);
-			}
+			return await Broker.SendRequestAsync(CmdId.Request_Player_ChangePlayerfield, arg);
 		}
 
 		public async Task<bool> Request_Player_ChangePlayerfield(IdPlayfieldPositionRotation arg, CancellationToken ct) {
 			return await Broker.SendRequestAsync(CmdId.Request_Player_ChangePlayerfield, arg, ct);
 		}
-		
-		public async Task<bool> Request_Player_ChangePlayerfield(Timeouts timeoutSeconds, IdPlayfieldPositionRotation arg) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_Player_ChangePlayerfield, arg, source.Token);
-			}
-		}
-
-		public async Task<bool> Request_Player_ChangePlayerfield(Timeouts timeoutSeconds, IdPlayfieldPositionRotation arg, CancellationToken ct) {
-			return await Broker.SendRequestAsync(CmdId.Request_Player_ChangePlayerfield, arg, ct);
-		}
 	
 		public async Task<ItemExchangeInfo> Request_Player_ItemExchange(ItemExchangeInfo arg) {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync<ItemExchangeInfo, ItemExchangeInfo>(CmdId.Request_Player_ItemExchange, arg, source.Token);
-			}
+			return await Broker.SendRequestAsync<ItemExchangeInfo, ItemExchangeInfo>(CmdId.Request_Player_ItemExchange, arg);
 		}
 
 		public async Task<ItemExchangeInfo> Request_Player_ItemExchange(ItemExchangeInfo arg, CancellationToken ct) {
 			return await Broker.SendRequestAsync<ItemExchangeInfo, ItemExchangeInfo>(CmdId.Request_Player_ItemExchange, arg, ct);
 		}
-		
-		public async Task<ItemExchangeInfo> Request_Player_ItemExchange(Timeouts timeoutSeconds, ItemExchangeInfo arg) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync<ItemExchangeInfo, ItemExchangeInfo>(CmdId.Request_Player_ItemExchange, arg, source.Token);
-			}
-		}
-
-		public async Task<ItemExchangeInfo> Request_Player_ItemExchange(Timeouts timeoutSeconds, ItemExchangeInfo arg, CancellationToken ct) {
-			return await Broker.SendRequestAsync<ItemExchangeInfo, ItemExchangeInfo>(CmdId.Request_Player_ItemExchange, arg, ct);
-		}
 	
 		public async Task<bool> Request_Player_SetPlayerInfo(PlayerInfoSet arg) {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_Player_SetPlayerInfo, arg, source.Token);
-			}
+			return await Broker.SendRequestAsync(CmdId.Request_Player_SetPlayerInfo, arg);
 		}
 
 		public async Task<bool> Request_Player_SetPlayerInfo(PlayerInfoSet arg, CancellationToken ct) {
 			return await Broker.SendRequestAsync(CmdId.Request_Player_SetPlayerInfo, arg, ct);
 		}
-		
-		public async Task<bool> Request_Player_SetPlayerInfo(Timeouts timeoutSeconds, PlayerInfoSet arg) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_Player_SetPlayerInfo, arg, source.Token);
-			}
-		}
-
-		public async Task<bool> Request_Player_SetPlayerInfo(Timeouts timeoutSeconds, PlayerInfoSet arg, CancellationToken ct) {
-			return await Broker.SendRequestAsync(CmdId.Request_Player_SetPlayerInfo, arg, ct);
-		}
 	
 		public async Task<bool> Request_Entity_Teleport(IdPositionRotation arg) {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_Entity_Teleport, arg, source.Token);
-			}
+			return await Broker.SendRequestAsync(CmdId.Request_Entity_Teleport, arg);
 		}
 
 		public async Task<bool> Request_Entity_Teleport(IdPositionRotation arg, CancellationToken ct) {
 			return await Broker.SendRequestAsync(CmdId.Request_Entity_Teleport, arg, ct);
 		}
-		
-		public async Task<bool> Request_Entity_Teleport(Timeouts timeoutSeconds, IdPositionRotation arg) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_Entity_Teleport, arg, source.Token);
-			}
-		}
-
-		public async Task<bool> Request_Entity_Teleport(Timeouts timeoutSeconds, IdPositionRotation arg, CancellationToken ct) {
-			return await Broker.SendRequestAsync(CmdId.Request_Entity_Teleport, arg, ct);
-		}
 	
 		public async Task<bool> Request_Entity_ChangePlayfield(IdPlayfieldPositionRotation arg) {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_Entity_ChangePlayfield, arg, source.Token);
-			}
+			return await Broker.SendRequestAsync(CmdId.Request_Entity_ChangePlayfield, arg);
 		}
 
 		public async Task<bool> Request_Entity_ChangePlayfield(IdPlayfieldPositionRotation arg, CancellationToken ct) {
 			return await Broker.SendRequestAsync(CmdId.Request_Entity_ChangePlayfield, arg, ct);
 		}
-		
-		public async Task<bool> Request_Entity_ChangePlayfield(Timeouts timeoutSeconds, IdPlayfieldPositionRotation arg) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_Entity_ChangePlayfield, arg, source.Token);
-			}
-		}
-
-		public async Task<bool> Request_Entity_ChangePlayfield(Timeouts timeoutSeconds, IdPlayfieldPositionRotation arg, CancellationToken ct) {
-			return await Broker.SendRequestAsync(CmdId.Request_Entity_ChangePlayfield, arg, ct);
-		}
 	
 		public async Task<bool> Request_Entity_Destroy(Id arg) {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_Entity_Destroy, arg, source.Token);
-			}
+			return await Broker.SendRequestAsync(CmdId.Request_Entity_Destroy, arg);
 		}
 
 		public async Task<bool> Request_Entity_Destroy(Id arg, CancellationToken ct) {
 			return await Broker.SendRequestAsync(CmdId.Request_Entity_Destroy, arg, ct);
 		}
-		
-		public async Task<bool> Request_Entity_Destroy(Timeouts timeoutSeconds, Id arg) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_Entity_Destroy, arg, source.Token);
-			}
-		}
-
-		public async Task<bool> Request_Entity_Destroy(Timeouts timeoutSeconds, Id arg, CancellationToken ct) {
-			return await Broker.SendRequestAsync(CmdId.Request_Entity_Destroy, arg, ct);
-		}
 	
 		public async Task<IdPositionRotation> Request_Entity_PosAndRot(Id arg) {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync<Id, IdPositionRotation>(CmdId.Request_Entity_PosAndRot, arg, source.Token);
-			}
+			return await Broker.SendRequestAsync<Id, IdPositionRotation>(CmdId.Request_Entity_PosAndRot, arg);
 		}
 
 		public async Task<IdPositionRotation> Request_Entity_PosAndRot(Id arg, CancellationToken ct) {
 			return await Broker.SendRequestAsync<Id, IdPositionRotation>(CmdId.Request_Entity_PosAndRot, arg, ct);
 		}
-		
-		public async Task<IdPositionRotation> Request_Entity_PosAndRot(Timeouts timeoutSeconds, Id arg) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync<Id, IdPositionRotation>(CmdId.Request_Entity_PosAndRot, arg, source.Token);
-			}
-		}
-
-		public async Task<IdPositionRotation> Request_Entity_PosAndRot(Timeouts timeoutSeconds, Id arg, CancellationToken ct) {
-			return await Broker.SendRequestAsync<Id, IdPositionRotation>(CmdId.Request_Entity_PosAndRot, arg, ct);
-		}
 	
 		public async Task<bool> Request_Entity_Spawn(EntitySpawnInfo arg) {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_Entity_Spawn, arg, source.Token);
-			}
+			return await Broker.SendRequestAsync(CmdId.Request_Entity_Spawn, arg);
 		}
 
 		public async Task<bool> Request_Entity_Spawn(EntitySpawnInfo arg, CancellationToken ct) {
 			return await Broker.SendRequestAsync(CmdId.Request_Entity_Spawn, arg, ct);
 		}
-		
-		public async Task<bool> Request_Entity_Spawn(Timeouts timeoutSeconds, EntitySpawnInfo arg) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_Entity_Spawn, arg, source.Token);
-			}
-		}
-
-		public async Task<bool> Request_Entity_Spawn(Timeouts timeoutSeconds, EntitySpawnInfo arg, CancellationToken ct) {
-			return await Broker.SendRequestAsync(CmdId.Request_Entity_Spawn, arg, ct);
-		}
 	
 		public async Task<FactionInfoList> Request_Get_Factions(Id arg) {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync<Id, FactionInfoList>(CmdId.Request_Get_Factions, arg, source.Token);
-			}
+			return await Broker.SendRequestAsync<Id, FactionInfoList>(CmdId.Request_Get_Factions, arg);
 		}
 
 		public async Task<FactionInfoList> Request_Get_Factions(Id arg, CancellationToken ct) {
 			return await Broker.SendRequestAsync<Id, FactionInfoList>(CmdId.Request_Get_Factions, arg, ct);
 		}
-		
-		public async Task<FactionInfoList> Request_Get_Factions(Timeouts timeoutSeconds, Id arg) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync<Id, FactionInfoList>(CmdId.Request_Get_Factions, arg, source.Token);
-			}
-		}
-
-		public async Task<FactionInfoList> Request_Get_Factions(Timeouts timeoutSeconds, Id arg, CancellationToken ct) {
-			return await Broker.SendRequestAsync<Id, FactionInfoList>(CmdId.Request_Get_Factions, arg, ct);
-		}
 	
 		public async Task<Id> Request_NewEntityId() {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync<Id>(CmdId.Request_NewEntityId, source.Token);
-			}
+			return await Broker.SendRequestAsync<Id>(CmdId.Request_NewEntityId);
 		}
 
 		public async Task<Id> Request_NewEntityId(CancellationToken ct) {
 			return await Broker.SendRequestAsync<Id>(CmdId.Request_NewEntityId, ct);
 		}
-		
-		public async Task<Id> Request_NewEntityId(Timeouts timeoutSeconds) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync<Id>(CmdId.Request_NewEntityId, source.Token);
-			}
-		}
-
-		public async Task<Id> Request_NewEntityId(Timeouts timeoutSeconds, CancellationToken ct) {
-			return await Broker.SendRequestAsync<Id>(CmdId.Request_NewEntityId, ct);
-		}
 	
 		public async Task<AlliancesTable> Request_AlliancesAll() {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync<AlliancesTable>(CmdId.Request_AlliancesAll, source.Token);
-			}
+			return await Broker.SendRequestAsync<AlliancesTable>(CmdId.Request_AlliancesAll);
 		}
 
 		public async Task<AlliancesTable> Request_AlliancesAll(CancellationToken ct) {
 			return await Broker.SendRequestAsync<AlliancesTable>(CmdId.Request_AlliancesAll, ct);
 		}
-		
-		public async Task<AlliancesTable> Request_AlliancesAll(Timeouts timeoutSeconds) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync<AlliancesTable>(CmdId.Request_AlliancesAll, source.Token);
-			}
-		}
-
-		public async Task<AlliancesTable> Request_AlliancesAll(Timeouts timeoutSeconds, CancellationToken ct) {
-			return await Broker.SendRequestAsync<AlliancesTable>(CmdId.Request_AlliancesAll, ct);
-		}
 	
 		public async Task<AlliancesFaction> Request_AlliancesFaction(AlliancesFaction arg) {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync<AlliancesFaction, AlliancesFaction>(CmdId.Request_AlliancesFaction, arg, source.Token);
-			}
+			return await Broker.SendRequestAsync<AlliancesFaction, AlliancesFaction>(CmdId.Request_AlliancesFaction, arg);
 		}
 
 		public async Task<AlliancesFaction> Request_AlliancesFaction(AlliancesFaction arg, CancellationToken ct) {
 			return await Broker.SendRequestAsync<AlliancesFaction, AlliancesFaction>(CmdId.Request_AlliancesFaction, arg, ct);
 		}
-		
-		public async Task<AlliancesFaction> Request_AlliancesFaction(Timeouts timeoutSeconds, AlliancesFaction arg) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync<AlliancesFaction, AlliancesFaction>(CmdId.Request_AlliancesFaction, arg, source.Token);
-			}
-		}
-
-		public async Task<AlliancesFaction> Request_AlliancesFaction(Timeouts timeoutSeconds, AlliancesFaction arg, CancellationToken ct) {
-			return await Broker.SendRequestAsync<AlliancesFaction, AlliancesFaction>(CmdId.Request_AlliancesFaction, arg, ct);
-		}
 	
 		public async Task<bool> Request_Load_Playfield(PlayfieldLoad arg) {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_Load_Playfield, arg, source.Token);
-			}
+			return await Broker.SendRequestAsync(CmdId.Request_Load_Playfield, arg);
 		}
 
 		public async Task<bool> Request_Load_Playfield(PlayfieldLoad arg, CancellationToken ct) {
 			return await Broker.SendRequestAsync(CmdId.Request_Load_Playfield, arg, ct);
 		}
-		
-		public async Task<bool> Request_Load_Playfield(Timeouts timeoutSeconds, PlayfieldLoad arg) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_Load_Playfield, arg, source.Token);
-			}
-		}
-
-		public async Task<bool> Request_Load_Playfield(Timeouts timeoutSeconds, PlayfieldLoad arg, CancellationToken ct) {
-			return await Broker.SendRequestAsync(CmdId.Request_Load_Playfield, arg, ct);
-		}
 	
 		public async Task<bool> Request_ConsoleCommand(PString arg) {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_ConsoleCommand, arg, source.Token);
-			}
+			return await Broker.SendRequestAsync(CmdId.Request_ConsoleCommand, arg);
 		}
 
 		public async Task<bool> Request_ConsoleCommand(PString arg, CancellationToken ct) {
 			return await Broker.SendRequestAsync(CmdId.Request_ConsoleCommand, arg, ct);
 		}
-		
-		public async Task<bool> Request_ConsoleCommand(Timeouts timeoutSeconds, PString arg) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_ConsoleCommand, arg, source.Token);
-			}
-		}
-
-		public async Task<bool> Request_ConsoleCommand(Timeouts timeoutSeconds, PString arg, CancellationToken ct) {
-			return await Broker.SendRequestAsync(CmdId.Request_ConsoleCommand, arg, ct);
-		}
 	
 		public async Task<IdList> Request_GetBannedPlayers() {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync<IdList>(CmdId.Request_GetBannedPlayers, source.Token);
-			}
+			return await Broker.SendRequestAsync<IdList>(CmdId.Request_GetBannedPlayers);
 		}
 
 		public async Task<IdList> Request_GetBannedPlayers(CancellationToken ct) {
 			return await Broker.SendRequestAsync<IdList>(CmdId.Request_GetBannedPlayers, ct);
 		}
-		
-		public async Task<IdList> Request_GetBannedPlayers(Timeouts timeoutSeconds) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync<IdList>(CmdId.Request_GetBannedPlayers, source.Token);
-			}
-		}
-
-		public async Task<IdList> Request_GetBannedPlayers(Timeouts timeoutSeconds, CancellationToken ct) {
-			return await Broker.SendRequestAsync<IdList>(CmdId.Request_GetBannedPlayers, ct);
-		}
 	
 		public async Task<bool> Request_InGameMessage_SinglePlayer(IdMsgPrio arg) {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_InGameMessage_SinglePlayer, arg, source.Token);
-			}
+			return await Broker.SendRequestAsync(CmdId.Request_InGameMessage_SinglePlayer, arg);
 		}
 
 		public async Task<bool> Request_InGameMessage_SinglePlayer(IdMsgPrio arg, CancellationToken ct) {
 			return await Broker.SendRequestAsync(CmdId.Request_InGameMessage_SinglePlayer, arg, ct);
 		}
-		
-		public async Task<bool> Request_InGameMessage_SinglePlayer(Timeouts timeoutSeconds, IdMsgPrio arg) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_InGameMessage_SinglePlayer, arg, source.Token);
-			}
-		}
-
-		public async Task<bool> Request_InGameMessage_SinglePlayer(Timeouts timeoutSeconds, IdMsgPrio arg, CancellationToken ct) {
-			return await Broker.SendRequestAsync(CmdId.Request_InGameMessage_SinglePlayer, arg, ct);
-		}
 	
 		public async Task<bool> Request_InGameMessage_AllPlayers(IdMsgPrio arg) {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_InGameMessage_AllPlayers, arg, source.Token);
-			}
+			return await Broker.SendRequestAsync(CmdId.Request_InGameMessage_AllPlayers, arg);
 		}
 
 		public async Task<bool> Request_InGameMessage_AllPlayers(IdMsgPrio arg, CancellationToken ct) {
 			return await Broker.SendRequestAsync(CmdId.Request_InGameMessage_AllPlayers, arg, ct);
 		}
-		
-		public async Task<bool> Request_InGameMessage_AllPlayers(Timeouts timeoutSeconds, IdMsgPrio arg) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_InGameMessage_AllPlayers, arg, source.Token);
-			}
-		}
-
-		public async Task<bool> Request_InGameMessage_AllPlayers(Timeouts timeoutSeconds, IdMsgPrio arg, CancellationToken ct) {
-			return await Broker.SendRequestAsync(CmdId.Request_InGameMessage_AllPlayers, arg, ct);
-		}
 	
 		public async Task<bool> Request_InGameMessage_Faction(IdMsgPrio arg) {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_InGameMessage_Faction, arg, source.Token);
-			}
+			return await Broker.SendRequestAsync(CmdId.Request_InGameMessage_Faction, arg);
 		}
 
 		public async Task<bool> Request_InGameMessage_Faction(IdMsgPrio arg, CancellationToken ct) {
 			return await Broker.SendRequestAsync(CmdId.Request_InGameMessage_Faction, arg, ct);
 		}
-		
-		public async Task<bool> Request_InGameMessage_Faction(Timeouts timeoutSeconds, IdMsgPrio arg) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_InGameMessage_Faction, arg, source.Token);
-			}
-		}
-
-		public async Task<bool> Request_InGameMessage_Faction(Timeouts timeoutSeconds, IdMsgPrio arg, CancellationToken ct) {
-			return await Broker.SendRequestAsync(CmdId.Request_InGameMessage_Faction, arg, ct);
-		}
 	
 		public async Task<IdAndIntValue> Request_ShowDialog_SinglePlayer(DialogBoxData arg) {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync<DialogBoxData, IdAndIntValue>(CmdId.Request_ShowDialog_SinglePlayer, arg, source.Token);
-			}
+			return await Broker.SendRequestAsync<DialogBoxData, IdAndIntValue>(CmdId.Request_ShowDialog_SinglePlayer, arg);
 		}
 
 		public async Task<IdAndIntValue> Request_ShowDialog_SinglePlayer(DialogBoxData arg, CancellationToken ct) {
 			return await Broker.SendRequestAsync<DialogBoxData, IdAndIntValue>(CmdId.Request_ShowDialog_SinglePlayer, arg, ct);
 		}
-		
-		public async Task<IdAndIntValue> Request_ShowDialog_SinglePlayer(Timeouts timeoutSeconds, DialogBoxData arg) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync<DialogBoxData, IdAndIntValue>(CmdId.Request_ShowDialog_SinglePlayer, arg, source.Token);
-			}
-		}
-
-		public async Task<IdAndIntValue> Request_ShowDialog_SinglePlayer(Timeouts timeoutSeconds, DialogBoxData arg, CancellationToken ct) {
-			return await Broker.SendRequestAsync<DialogBoxData, IdAndIntValue>(CmdId.Request_ShowDialog_SinglePlayer, arg, ct);
-		}
 	
 		public async Task<Inventory> Request_Player_GetAndRemoveInventory(Id arg) {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync<Id, Inventory>(CmdId.Request_Player_GetAndRemoveInventory, arg, source.Token);
-			}
+			return await Broker.SendRequestAsync<Id, Inventory>(CmdId.Request_Player_GetAndRemoveInventory, arg);
 		}
 
 		public async Task<Inventory> Request_Player_GetAndRemoveInventory(Id arg, CancellationToken ct) {
 			return await Broker.SendRequestAsync<Id, Inventory>(CmdId.Request_Player_GetAndRemoveInventory, arg, ct);
 		}
-		
-		public async Task<Inventory> Request_Player_GetAndRemoveInventory(Timeouts timeoutSeconds, Id arg) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync<Id, Inventory>(CmdId.Request_Player_GetAndRemoveInventory, arg, source.Token);
-			}
-		}
-
-		public async Task<Inventory> Request_Player_GetAndRemoveInventory(Timeouts timeoutSeconds, Id arg, CancellationToken ct) {
-			return await Broker.SendRequestAsync<Id, Inventory>(CmdId.Request_Player_GetAndRemoveInventory, arg, ct);
-		}
 	
 		public async Task<PlayfieldEntityList> Request_Playfield_Entity_List(PString arg) {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync<PString, PlayfieldEntityList>(CmdId.Request_Playfield_Entity_List, arg, source.Token);
-			}
+			return await Broker.SendRequestAsync<PString, PlayfieldEntityList>(CmdId.Request_Playfield_Entity_List, arg);
 		}
 
 		public async Task<PlayfieldEntityList> Request_Playfield_Entity_List(PString arg, CancellationToken ct) {
 			return await Broker.SendRequestAsync<PString, PlayfieldEntityList>(CmdId.Request_Playfield_Entity_List, arg, ct);
 		}
-		
-		public async Task<PlayfieldEntityList> Request_Playfield_Entity_List(Timeouts timeoutSeconds, PString arg) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync<PString, PlayfieldEntityList>(CmdId.Request_Playfield_Entity_List, arg, source.Token);
-			}
-		}
-
-		public async Task<PlayfieldEntityList> Request_Playfield_Entity_List(Timeouts timeoutSeconds, PString arg, CancellationToken ct) {
-			return await Broker.SendRequestAsync<PString, PlayfieldEntityList>(CmdId.Request_Playfield_Entity_List, arg, ct);
-		}
 	
 		public async Task<bool> Request_Entity_Destroy2(IdPlayfield arg) {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_Entity_Destroy2, arg, source.Token);
-			}
+			return await Broker.SendRequestAsync(CmdId.Request_Entity_Destroy2, arg);
 		}
 
 		public async Task<bool> Request_Entity_Destroy2(IdPlayfield arg, CancellationToken ct) {
 			return await Broker.SendRequestAsync(CmdId.Request_Entity_Destroy2, arg, ct);
 		}
-		
-		public async Task<bool> Request_Entity_Destroy2(Timeouts timeoutSeconds, IdPlayfield arg) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_Entity_Destroy2, arg, source.Token);
-			}
-		}
-
-		public async Task<bool> Request_Entity_Destroy2(Timeouts timeoutSeconds, IdPlayfield arg, CancellationToken ct) {
-			return await Broker.SendRequestAsync(CmdId.Request_Entity_Destroy2, arg, ct);
-		}
 	
 		public async Task<bool> Request_Entity_Export(EntityExportInfo arg) {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_Entity_Export, arg, source.Token);
-			}
+			return await Broker.SendRequestAsync(CmdId.Request_Entity_Export, arg);
 		}
 
 		public async Task<bool> Request_Entity_Export(EntityExportInfo arg, CancellationToken ct) {
 			return await Broker.SendRequestAsync(CmdId.Request_Entity_Export, arg, ct);
 		}
-		
-		public async Task<bool> Request_Entity_Export(Timeouts timeoutSeconds, EntityExportInfo arg) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_Entity_Export, arg, source.Token);
-			}
-		}
-
-		public async Task<bool> Request_Entity_Export(Timeouts timeoutSeconds, EntityExportInfo arg, CancellationToken ct) {
-			return await Broker.SendRequestAsync(CmdId.Request_Entity_Export, arg, ct);
-		}
 	
 		public async Task<bool> Request_Entity_SetName(IdPlayfieldName arg) {
-			using (var source = new CancellationTokenSource(EmpyrionRequestsDefaultTimeout.Milliseconds))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_Entity_SetName, arg, source.Token);
-			}
+			return await Broker.SendRequestAsync(CmdId.Request_Entity_SetName, arg);
 		}
 
 		public async Task<bool> Request_Entity_SetName(IdPlayfieldName arg, CancellationToken ct) {
-			return await Broker.SendRequestAsync(CmdId.Request_Entity_SetName, arg, ct);
-		}
-		
-		public async Task<bool> Request_Entity_SetName(Timeouts timeoutSeconds, IdPlayfieldName arg) {
-			using (var source = new CancellationTokenSource((int)timeoutSeconds * 1000))
-			{
-				return await Broker.SendRequestAsync(CmdId.Request_Entity_SetName, arg, source.Token);
-			}
-		}
-
-		public async Task<bool> Request_Entity_SetName(Timeouts timeoutSeconds, IdPlayfieldName arg, CancellationToken ct) {
 			return await Broker.SendRequestAsync(CmdId.Request_Entity_SetName, arg, ct);
 		}
 	}

--- a/EmpyrionNetAPIModBase/Autowire.ModBase.APIRequestsDefinition.tt
+++ b/EmpyrionNetAPIModBase/Autowire.ModBase.APIRequestsDefinition.tt
@@ -41,14 +41,6 @@ namespace EmpyrionNetAPIAccess
 		public async <#= signatureCT #> {
 			<#= signatureCT.GetMethodBodyTemplate() #>
 		}
-		
-		public async <#= signatureTimeout #> {
-			<#= signatureTimeout.GetMethodBodyTemplate() #>
-		}
-
-		public async <#= signatureTimeoutCT #> {
-			<#= signatureTimeoutCT.GetMethodBodyTemplate() #>
-		}
 	<# } #>}
 }
 
@@ -117,30 +109,18 @@ namespace EmpyrionNetAPIAccess
 		public string GetMethodBodyTemplate()
 		{
 			var sendRequestTemplate = GetSendRequestTemplateInfo("arg");
-			var timeoutTemplate = "EmpyrionRequestsDefaultTimeout";
-			var ctokenTimeoutTemplate = "EmpyrionRequestsDefaultTimeout.Milliseconds";
-			
-			if (HasArgWithName("timeoutSeconds"))			
-			{
-				timeoutTemplate = "(int)timeoutSeconds";
-				ctokenTimeoutTemplate = "(int)timeoutSeconds * 1000";
-			}
 
 			if (HasArgWithName("ct"))
 			{
 				return (returnType == null)
-						? string.Format("return await Broker.SendRequestAsync({1}, ct);", timeoutTemplate, sendRequestTemplate.ParametersTemplate)
-						: string.Format("return await Broker.SendRequestAsync<{1}>({2}, ct);", timeoutTemplate, sendRequestTemplate.GenericsTemplate, sendRequestTemplate.ParametersTemplate);
+						? string.Format("return await Broker.SendRequestAsync({0}, ct);", sendRequestTemplate.ParametersTemplate)
+						: string.Format("return await Broker.SendRequestAsync<{0}>({1}, ct);", sendRequestTemplate.GenericsTemplate, sendRequestTemplate.ParametersTemplate);
 			} 
 			else 
 			{				
-				return string.Join(string.Concat(Environment.NewLine, "			"), 
-					string.Format("using (var source = new CancellationTokenSource({0}))", ctokenTimeoutTemplate), 
-					"{",
-					(returnType == null)
-						? string.Format("	return await Broker.SendRequestAsync({1}, source.Token);", timeoutTemplate, sendRequestTemplate.ParametersTemplate)
-						: string.Format("	return await Broker.SendRequestAsync<{1}>({2}, source.Token);", timeoutTemplate, sendRequestTemplate.GenericsTemplate, sendRequestTemplate.ParametersTemplate),
-					"}");
+				return (returnType == null)
+						? string.Format("return await Broker.SendRequestAsync({0});", sendRequestTemplate.ParametersTemplate)
+						: string.Format("return await Broker.SendRequestAsync<{0}>({1});", sendRequestTemplate.GenericsTemplate, sendRequestTemplate.ParametersTemplate);
 			}
 		}
 
@@ -166,9 +146,6 @@ namespace EmpyrionNetAPIAccess
 		result.methodName = item.CmdId.ToString();
 
 		var tmpArgList = new List<GenericArg>();		
-
-		if (withTimeout) 
-			tmpArgList.Add(new GenericArg("timeoutSeconds", "Timeouts"));
     
 		if (item.ParamType != null)
 			tmpArgList.Add(new GenericArg("arg", item.ParamType.Name));	


### PR DESCRIPTION
- adds try-block and default type return for timeouts of Requests that define CancellationTokenSources in their scope
- removes using block and CancellationTokenSources in ModBase Request methods, should just call the appropriate Broker method. 